### PR TITLE
Update ep3 from v1.0.0 to v1.7.0

### DIFF
--- a/sapporo/service-info.json
+++ b/sapporo/service-info.json
@@ -21,7 +21,7 @@
     "toil (experimental)": "4.1.0",
     "cromwell": "55",
     "snakemake": "v5.32.0",
-    "ep3 (experimental)": "v1.0.0"
+    "ep3 (experimental)": "v1.7.0"
   },
   "auth_instructions_url": "https://github.com/ddbj/sapporo-service",
   "contact_info_url": "https://github.com/ddbj/sapporo-service",


### PR DESCRIPTION
It supports a metrics collection feature (compatible with [CWL-metrics](https://inutano.github.io/cwl-metrics/) format 0.2.0).
- Release note: https://github.com/tom-tan/ep3/releases/tag/v1.7.0